### PR TITLE
fix: add global CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,4 @@
 # This file specifies the people currently responsible for code reviews in the repository.
 # For information about the owners of the code, please refer to the LICENSE and README files.
 
-@alessandroberlati
-@earien
-@ocardia
-@xelhark
+* @alessandroberlati @earien @ocardia @xelhark


### PR DESCRIPTION
## Description

Add global codeowners.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-reporting/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #6 
