### PR TITLE
feat(api): uvicorn workers with lifespan=on

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ case "$1" in
             --logger-class=immuni_common.helpers.logging.CustomGunicornLogger \
             --max-requests=${API_WORKER_MAX_REQUESTS} \
             --workers=${API_WORKERS} \
-            --worker-class=uvicorn.workers.UvicornWorker ;;
+            --worker-class=immuni_common.uvicorn.ImmuniUvicornWorker ;;
     debug) echo "Running in debug mode ..." \
             && tail -f /dev/null ;;  # Allow entering the container to inspect the environment.
     *) echo "Received unknown command $1 (allowed: api)"


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-reporting/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Use `lifespan=on` immuni uvicorn workers to catch exceptions within the managers initialization.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-reporting/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
